### PR TITLE
fix(docker): add Redis password configuration and create temporary directory for application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ RUN apk add --no-cache ffmpeg ffmpeg-libs curl \
 
 # Set the working directory in the container
 WORKDIR /app
+
+# Create directory for temporary file storage (e.g., video processing, MinIO uploads)
+RUN mkdir -p /vinaacademy/temp && chown -R vinaacademy:vinaacademy /vinaacademy
+
 COPY --from=build /app/target/VinaAcademy-*.jar app.jar
 RUN chown vinaacademy:vinaacademy app.jar
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,6 +34,7 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST:localhost}
       port: ${SPRING_DATA_REDIS_PORT:6379}
       default-ttl: ${SPRING_DATA_REDIS_DEFAULT_TTL:3600}
+      password: ${SPRING_DATA_REDIS_PASSWORD:}
 
   jpa:
     properties:


### PR DESCRIPTION
This pull request introduces infrastructure improvements to better support file storage and secure Redis connections in the development environment. The most notable changes are the creation of a dedicated temporary storage directory in the Docker image and the addition of Redis password configuration.

Infrastructure and environment setup:

* Dockerfile: Added creation of `/vinaacademy/temp` directory for temporary file storage and ensured correct ownership by the `vinaacademy` user. This supports video processing and MinIO uploads.

Development configuration:

* [`src/main/resources/application-dev.yml`](diffhunk://#diff-56a2780642d5bbabb1f74b4a9d6b0e33d43a672aba82f69b0d346b077d31f06dR37): Added support for specifying a Redis password via the `SPRING_DATA_REDIS_PASSWORD` environment variable, improving security and flexibility for Redis connections.