### PR TITLE
hotfix(notification): add COURSE_APPROVAL notification type to video processing

### DIFF
--- a/src/main/java/com/vinaacademy/platform/feature/video/service/impl/VideoProcessorServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/video/service/impl/VideoProcessorServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import vn.vinaacademy.kafka.event.NotificationCreateEvent;
+import vn.vinaacademy.kafka.event.NotificationCreateEvent.NotificationType;
 
 @Slf4j
 @Service
@@ -132,6 +133,7 @@ public class VideoProcessorServiceImpl implements VideoProcessorService {
                 .content("Bạn có thể xem tại đây.")
                 .targetUrl(frontendUrl + "/instructor/courses/" + courseId + "/lectures/" + video.getId())
                 .userId(video.getAuthor().getId())
+                .type(NotificationType.COURSE_APPROVAL)
                 .build());
     }
 
@@ -142,6 +144,7 @@ public class VideoProcessorServiceImpl implements VideoProcessorService {
                 .content("Có lỗi xảy ra: " + errorMessage)
                 .targetUrl(frontendUrl + "/instructor/courses/" + courseId + "/lectures/" + video.getId())
                 .userId(video.getAuthor().getId())
+                .type(NotificationType.COURSE_APPROVAL)
                 .build());
     }
 


### PR DESCRIPTION
This pull request improves the notification system in the video processing service by specifying the notification type when sending notifications for both successful and failed video processing events. This ensures that notifications are categorized correctly, which can help with filtering and handling on the frontend.

Enhancements to notification events:

* Added the `NotificationType.COURSE_APPROVAL` type to notifications sent on both successful (`notifySuccess`) and failed (`notifyFailure`) video processing, ensuring consistent notification categorization. [[1]](diffhunk://#diff-2473ef8b4cbdff769da44591acd5a142486aac370e075ba4fa5800e74d724556R136) [[2]](diffhunk://#diff-2473ef8b4cbdff769da44591acd5a142486aac370e075ba4fa5800e74d724556R147)
* Imported the `NotificationType` enum from `NotificationCreateEvent` to support the new notification type field.