### PR TITLE
add workflow dispatch for environment selection and update deployment logic

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -3,6 +3,16 @@ name: VinaAcademy Platform - CI/CD Pipeline
 on:
   push:
     branches: [ develop ]   # deploy when new code is pushed to main/master branch
+  workflow_dispatch:
+    inputs:
+      deploy-environment:
+        description: 'Select the environment to deploy to'
+        required: true
+        default: 'development'
+        type: choice
+        options:
+          - development
+          - production
 
 jobs:
   test:
@@ -100,15 +110,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-and-push
-    environment: production
+    environment: ${{ github.event.inputs.deploy-environment || 'development' }}
     steps:
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1.0.0
         with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          password: ${{ secrets.VPS_PASSWORD }}
-          port: ${{ secrets.VPS_PORT || 22 }}
+          host: ${{ github.event.inputs.deploy-environment == 'production' && secrets.VPS_PROD_HOST || secrets.VPS_DEV_HOST }}
+          username: ${{ github.event.inputs.deploy-environment == 'production' && secrets.VPS_PROD_USERNAME || secrets.VPS_DEV_USERNAME }}
+          password: ${{ github.event.inputs.deploy-environment == 'production' && secrets.VPS_PROD_PASSWORD || secrets.VPS_DEV_PASSWORD }}
+          port: ${{ github.event.inputs.deploy-environment == 'production' && secrets.VPS_PROD_PORT || secrets.VPS_DEV_PORT || 22 }}
           script: |
             # Navigate to deployment directory
             cd /root/ms-ci-cd

--- a/src/main/java/com/vinaacademy/platform/feature/TestingDataService.java
+++ b/src/main/java/com/vinaacademy/platform/feature/TestingDataService.java
@@ -8,6 +8,7 @@ import com.vinaacademy.platform.feature.common.utils.SlugUtils;
 import com.vinaacademy.platform.feature.course.entity.Course;
 import com.vinaacademy.platform.feature.course.enums.CourseLevel;
 import com.vinaacademy.platform.feature.course.enums.CourseStatus;
+import com.vinaacademy.platform.feature.course.enums.LessonStatus;
 import com.vinaacademy.platform.feature.course.repository.CourseRepository;
 import com.vinaacademy.platform.feature.instructor.CourseInstructor;
 import com.vinaacademy.platform.feature.instructor.repository.CourseInstructorRepository;
@@ -30,17 +31,18 @@ import com.vinaacademy.platform.feature.user.constant.AuthConstants;
 import com.vinaacademy.platform.feature.user.entity.User;
 import com.vinaacademy.platform.feature.user.role.entity.Role;
 import com.vinaacademy.platform.feature.user.role.repository.RoleRepository;
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -511,6 +513,7 @@ public class TestingDataService {
                         .free(false)
                         .orderIndex(0)
                         .author(instructor)
+                        .lessonStatus(LessonStatus.PUBLISHED)
                         .content(selectAppropriateContent(name, description, category.getName()))
                         .build();
 
@@ -527,6 +530,7 @@ public class TestingDataService {
                         .passingScore(50.0)
                         .totalPoints(75.0)
                         .duration(15)
+                        .lessonStatus(LessonStatus.PUBLISHED)
                         .randomizeQuestions(true)
                         .showCorrectAnswers(true)
                         .allowRetake(true)


### PR DESCRIPTION
This pull request introduces improvements to the CI/CD pipeline configuration and enhances the test data generation for courses. The main updates allow for environment selection during deployments and ensure that created courses and quizzes have their lesson status set to "PUBLISHED".

**CI/CD Pipeline Enhancements:**

* Added a `workflow_dispatch` trigger to `.github/workflows/cicd-dev.yml`, enabling manual deployments with an environment selector (`development` or `production`).
* Updated the deploy job to dynamically select deployment environment and secrets based on the chosen environment, supporting both development and production deployments.

**Testing Data Improvements:**

* Set `lessonStatus` to `LessonStatus.PUBLISHED` when creating course and quiz test data to ensure they are properly published in the test environment. [[1]](diffhunk://#diff-d2e41e6d72bf9d206745df5ffc3d1f8cba6c62b674de89031eddd3954bbbeb7eR516) [[2]](diffhunk://#diff-d2e41e6d72bf9d206745df5ffc3d1f8cba6c62b674de89031eddd3954bbbeb7eR533)
* Added the necessary import for `LessonStatus` and reorganized imports for clarity in `TestingDataService.java`. [[1]](diffhunk://#diff-d2e41e6d72bf9d206745df5ffc3d1f8cba6c62b674de89031eddd3954bbbeb7eR11) [[2]](diffhunk://#diff-d2e41e6d72bf9d206745df5ffc3d1f8cba6c62b674de89031eddd3954bbbeb7eL33-R46)