### PR TITLE
Add custom handling for MethodArgumentNotValid exceptions in GlobalExceptionHandlerAdvice

### DIFF
--- a/src/main/java/com/vinaacademy/platform/exception/GlobalExceptionHandlerAdvice.java
+++ b/src/main/java/com/vinaacademy/platform/exception/GlobalExceptionHandlerAdvice.java
@@ -1,34 +1,35 @@
 package com.vinaacademy.platform.exception;
 
-import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
-
 import com.vinaacademy.platform.feature.common.exception.ResourceNotFoundException;
 import com.vinaacademy.platform.feature.common.response.ApiResponse;
 import com.vinaacademy.platform.feature.common.service.MessageService;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.validation.BindException;
-import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 
 /**
  * Global exception handler with internationalization support.
@@ -258,6 +259,15 @@ public class GlobalExceptionHandlerAdvice extends ResponseEntityExceptionHandler
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error(500, resolveMessage("operation.failed", null, null)));
+    }
+
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers,
+                                                                  HttpStatusCode status, WebRequest request) {
+        this.logger.error(e.getMessage(), e.getCause());
+        List<String> errors = e.getBindingResult().getFieldErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage).toList();
+        return ResponseEntity.badRequest().body(vn.vinaacademy.common.response
+                .ApiResponse.error(String.join(", ", errors)));
     }
 
     /**


### PR DESCRIPTION
This pull request refactors the import statements in `GlobalExceptionHandlerAdvice.java` for better organization and adds a new handler for method argument validation errors. The new handler method provides more informative error responses when validation fails for controller method arguments.

**Exception handling improvements:**

* Added `handleMethodArgumentNotValid` method to handle `MethodArgumentNotValidException`, logging the error and returning a bad request response with all validation error messages concatenated.

**Code organization:**

* Refactored and reordered import statements in `GlobalExceptionHandlerAdvice.java` for clarity and consistency.